### PR TITLE
Install as a Python package with setup.py 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 **/*.rs.bk
 Cargo.lock
 python/pyargmin.so
+build
+*.egg-info
+dist/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyargmin"
-version = "0.0.0"
+version = "0.0.1"
 authors = ["Stefan Kroboth <stefan.kroboth@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -18,13 +18,14 @@ exclude = [
 ]
 
 [lib]
-name = "pyargmin"
+name = "_lib"
 crate-type = ["cdylib"]
 
 [dependencies]
 # argmin_core = { path = "../argmin-core" }
-argmin = { path = "../argmin", features = ["ctrlc", "ndarrayl"]}
-pyo3 = { version = "0.6.0", features = ["extension-module"] }
+# argmin = { path = "../argmin", features = ["ctrlc", "ndarrayl"]}
+argmin = {version = "0.2.4", features = ["ctrlc", "ndarrayl"]}
+pyo3 = { version = "0.7.0", features = ["extension-module"] }
 serde = "1.0"
-numpy = "0.5.0"
+numpy = "0.6.0"
 ndarray = "*"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# pyargmin
+
+Mathematical optimization in pure Rust accessible from Python
+
+
+## Install
+
+pyargmin requires Python 3.5+ and can be installed with,
+```
+python setup.py install
+```
+
+## Usage
+
+An example can be run with,
+```
+python examples/test1.py
+```
+
+
+## License
+
+pyargmin is released under the [Apache License, Version 2.0](./LICENSE-APACHE) or
+[MIT](./LICENSE-MIT) license.

--- a/argmin/__init__.py
+++ b/argmin/__init__.py
@@ -1,0 +1,1 @@
+from ._lib import *  # noqa

--- a/examples/test1.py
+++ b/examples/test1.py
@@ -12,7 +12,7 @@ fu
 """
 
 import numpy as np
-import pyargmin as argmin
+import argmin
 
 
 def blah(inp):
@@ -37,8 +37,8 @@ class Problem:
         x = param[0]
         y = param[1]
         out = np.array(
-                [-2.0 * self.a + 4.0 * self.b * x**3 - 4.0 * self.b * x * y + 2.0 * x,
-                 2.0 * self.b * (y - x**2)])
+                [-2.0 * self.a + 4.0 * self.b * x**3 - 4.0 * self.b * x * y
+                 + 2.0 * x, 2.0 * self.b * (y - x**2)])
         return out
 
 

--- a/justfile
+++ b/justfile
@@ -2,5 +2,5 @@ build:
   cargo +nightly build --release
 
 run: build
-  cp target/release/libpyargmin.so python/pyargmin.so
+  cp target/release/_lib.so python/pyargmin.so
   cd python && python test1.py

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+from setuptools import find_packages, setup
+from setuptools_rust import RustExtension
+
+
+setup_requires = ['setuptools-rust>=0.6.0']
+install_requires = ['numpy']
+test_requires = install_requires + ['pytest']
+
+setup(
+    name='pyargmin',
+    version='0.0.1',
+    description='Mathematical optimization in pure Rust accessible '
+                'from Python',
+    rust_extensions=[RustExtension(
+        'argmin._lib',
+        './Cargo.toml',
+    )],
+    install_requires=install_requires,
+    setup_requires=setup_requires,
+    test_requires=test_requires,
+    packages=find_packages(),
+    zip_safe=False,
+)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ fn executor(op: PyObject, solver: &mut PyLandweber, init_param: PyObject) -> Py<
 
 /// python module
 #[pymodule]
-fn pyargmin(_py: Python, m: &PyModule) -> PyResult<()> {
+fn _lib(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(closure))?;
     m.add_wrapped(wrap_pyfunction!(closure3))?;
     m.add_wrapped(wrap_pyfunction!(landweber))?;

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -109,6 +109,7 @@ where
     type Param = ParamKind;
     type Output = f64;
     type Hessian = ();
+    type Jacobian = ParamKind;
 
     fn apply(&self, x: &Self::Param) -> Result<Self::Output, Error> {
         let gil_guard = Python::acquire_gil();


### PR DESCRIPTION
Allows to install this repo as a python package with with `setuptools-rust`. Adds a readme with minimal installation instructions.

`setup.py` adapted from a `rust-numpy` example.

Also updated to Pyo3 0.7 and rust-numpy 0.6.