### PR TITLE
Add a lint CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   build-test:
     working_directory: ~/repo
     docker:
-      - image: rust:1.38-buster
+      - image: rust:1.42-buster
     steps:
       - checkout
       - run:
@@ -13,7 +13,7 @@ jobs:
             apt-get update
             apt install -y python3-pip libopenblas-dev gfortran
             python3.7 -m pip install tox 'setuptools-rust>=0.6.0'
-            rustup default nightly-2019-09-26
+            rustup default nightly-2020-03-01
       - run:
           name: install
           command: |
@@ -21,10 +21,32 @@ jobs:
       - run:
           name: test
           command: |
+            set -x
             cd /tmp/
             python3.7 -m pip install pytest pytest-faulthandler
             python3.7 -m pytest --pyargs argmin
             cd -
+
+  lint:
+    working_directory: ~/repo
+    docker:
+      - image: rust:1.42-buster
+    steps:
+      - checkout
+      - run:
+          name: dependencies
+          command: |
+            apt-get update
+            apt install -y python3-pip libopenblas-dev gfortran
+            python3.7 -m pip install tox 'setuptools-rust>=0.6.0' black
+            rustup default nightly-2020-03-01
+      - run:
+          name: cargo fmt
+          command: cargo fmt -- --check
+      - run:
+          name: black
+          command: black --check examples/ argmin/
+
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,3 +53,4 @@ workflows:
   build:
     jobs:
       - build-test
+      - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ jobs:
             apt install -y python3-pip libopenblas-dev gfortran
             python3.7 -m pip install tox 'setuptools-rust>=0.6.0'
             rustup default nightly-2020-03-01
+            rustup component add rustfmt
       - run:
           name: install
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,6 @@ jobs:
             apt install -y python3-pip libopenblas-dev gfortran
             python3.7 -m pip install tox 'setuptools-rust>=0.6.0'
             rustup default nightly-2020-03-01
-            rustup component add rustfmt
       - run:
           name: install
           command: |
@@ -41,6 +40,7 @@ jobs:
             apt install -y python3-pip libopenblas-dev gfortran
             python3.7 -m pip install tox 'setuptools-rust>=0.6.0' black
             rustup default nightly-2020-03-01
+            rustup component add rustfmt
       - run:
           name: cargo fmt
           command: cargo fmt -- --check

--- a/argmin/tests/test_argmin.py
+++ b/argmin/tests/test_argmin.py
@@ -1,4 +1,3 @@
-
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
@@ -6,28 +5,24 @@ from numpy.testing import assert_allclose
 import argmin
 
 
-@pytest.mark.parametrize('solver_name', ['lbfgs'])
+@pytest.mark.parametrize("solver_name", ["lbfgs"])
 def test_rosen_lbfgs(solver_name):
     # Adapted from scipy.optimize.tests.test_optimize
 
-    scipy_opt = pytest.importorskip('scipy.optimize')
+    scipy_opt = pytest.importorskip("scipy.optimize")
 
-    class Rosen():
+    class Rosen:
         def apply(self, x):
-            res = scipy_opt.rosen(x)
-            print('Roman.apply', x, res)
-            return res
+            return scipy_opt.rosen(x)
 
         def gradient(self, x):
-            res = scipy_opt.rosen_der(x)
-            print('Rosen.gradient', x, res)
-            return res
+            return scipy_opt.rosen_der(x)
 
     prob = Rosen()
 
     x0 = np.array([-1.2, 1.0])
 
-    if solver_name == 'lbfgs':
+    if solver_name == "lbfgs":
         solver = argmin.lbfgs(10)
     else:
         raise NotImplementedError

--- a/examples/test1.py
+++ b/examples/test1.py
@@ -25,15 +25,18 @@ class Problem:
 
     def apply(self, param):
         """apply"""
-        out = (self.a - param[0])**2 + self.b * (param[1] - param[0]**2)**2
+        out = (self.a - param[0]) ** 2 + self.b * (param[1] - param[0] ** 2) ** 2
         return out
 
     def gradient(self, param):
         x = param[0]
         y = param[1]
         out = np.array(
-                [-2.0 * self.a + 4.0 * self.b * x**3 - 4.0 * self.b * x * y
-                 + 2.0 * x, 2.0 * self.b * (y - x**2)])
+            [
+                -2.0 * self.a + 4.0 * self.b * x ** 3 - 4.0 * self.b * x * y + 2.0 * x,
+                2.0 * self.b * (y - x ** 2),
+            ]
+        )
         return out
 
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -46,7 +46,7 @@ impl PyExecutor {
         Ok(())
     }
 
-    fn run(&self) -> PyResult<(Py<PyArray1<f64>>)> {
+    fn run(&self) -> PyResult<Py<PyArray1<f64>>> {
         let executor = self.exec.clone();
         let res = executor.run().unwrap();
         let x = match res.state.param {


### PR DESCRIPTION
Adds a lint CI job,
 - run `cargo fmt` for Rust
 - run [black](https://github.com/psf/black) for Python

Also update Rust used in CI to nightly-2020-03-01.